### PR TITLE
RDM-5734 Change search results to have more detail

### DIFF
--- a/app/assets/stylesheets/geodisy.scss
+++ b/app/assets/stylesheets/geodisy.scss
@@ -163,3 +163,33 @@ hr.metadata-divider {
 .card-header {
     font-weight: 500;
 }
+
+@media (min-width: 1400px) {
+  .container {
+      max-width: 95% !important;
+  }
+}
+
+.index_title > span > a {
+    color: black;
+    font-size: 1.3em;
+    margin-bottom: 0px;
+    overflow-x: inherit;
+    white-space: normal;
+}
+
+.index_creators {
+    font-style: italic;
+}
+
+.index_date {
+    font-style: italic;
+}
+
+.documents-list .document {
+    border-bottom: 1px solid #dee2e6;
+}
+
+.repo-icon {
+    width: 72px;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -105,25 +105,9 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    # config.add_index_field 'title_display', :label => 'Title:'
-    # config.add_index_field 'title_vern_display', :label => 'Title:'
-    # config.add_index_field 'author_display', :label => 'Author:'
-    # config.add_index_field 'author_vern_display', :label => 'Author:'
-    # config.add_index_field 'format', :label => 'Format:'
-    # config.add_index_field 'language_facet', :label => 'Language:'
-    # config.add_index_field 'published_display', :label => 'Published:'
-    # config.add_index_field 'published_vern_display', :label => 'Published:'
-    # config.add_index_field 'lc_callnum_display', :label => 'Call number:'
-
-    # config.add_index_field 'dc_title_t', :label => 'Display Name:'
-    # config.add_index_field Settings.FIELDS.PROVENANCE, :label => 'Institution:'
-    # config.add_index_field Settings.FIELDS.RIGHTS, :label => 'Access:'
-    # # config.add_index_field 'Area', :label => 'Area:'
-    # config.add_index_field Settings.FIELDS.SUBJECT, :label => 'Keywords:'
-    config.add_index_field Settings.FIELDS.YEAR
-    config.add_index_field Settings.FIELDS.CREATOR
-    config.add_index_field Settings.FIELDS.DESCRIPTION, helper_method: :snippit
     config.add_index_field Settings.FIELDS.PUBLISHER
+    config.add_index_field Settings.FIELDS.CREATOR
+    config.add_index_field Settings.FIELDS.YEAR
 
 
 

--- a/app/views/catalog/_document_split.html.erb
+++ b/app/views/catalog/_document_split.html.erb
@@ -1,0 +1,7 @@
+<div class='row'>
+  <div id="documents" class="documents-list col-md-6">
+    <%= render 'sort_and_per_page' %>
+    <%= render documents, :as => :document %>
+  </div>
+  <%= content_tag :div, '', id: 'map', class: 'col-md-6', aria: { label: t('geoblacklight.map.label') }, data: { map: 'index', 'catalog-path'=> search_catalog_path , 'map-bbox' => params[:bbox], basemap: geoblacklight_basemap, leaflet_options: leaflet_options } %>
+</div>

--- a/app/views/catalog/_index_split_default.html.erb
+++ b/app/views/catalog/_index_split_default.html.erb
@@ -1,0 +1,34 @@
+<% # header bar for doc items in index view -%>
+<% icon_src = "" %>
+<% icon_src = document[Settings.FIELDS.SOURCE_ICON] if !document[Settings.FIELDS.SOURCE_ICON].blank? %>
+<%= content_tag :div, class: 'documentHeader row', data: { layer_id: document.id, bbox: document.bounding_box_as_wsen } do %>
+  <span class="col-2 col-md-3 col-xl-2 p-0">
+    <img class="pull-right repo-icon" src="<%= icon_src %>"/>
+  </span>
+  <span class="col-10 col-md-9 col-xl-10">
+    <div class="index_title col">
+      <span class="title-wrapper">
+        <%= link_to_document document, title: document[blacklight_config.index.title_field] %>
+      </span>
+      <span class='status-icons'>
+        <%= render partial: 'header_icons', locals: { document: document } %>
+      </span>
+    </div>
+
+    <div class='col more-info-area'>
+      <div class="index_publisher">
+        <%= document[Settings.FIELDS.PUBLISHER] %>
+      </div>
+      <% if document[Settings.FIELDS.DATE_PUBLISHED].blank? || document[Settings.FIELDS.DATE_PUBLISHED].nil?
+           date = ""
+         else
+           date = " — " + document[Settings.FIELDS.DATE_PUBLISHED]
+         end
+         creators = document[Settings.FIELDS.CREATOR].join("; ")
+       %>
+      <div>
+        <span class="index_creators"><%= creators %></span><span class="index_date"><%= date %></span>
+      </div>
+    </div>
+  </span>
+<% end %>

--- a/app/views/catalog/_search_header.html.erb
+++ b/app/views/catalog/_search_header.html.erb
@@ -1,0 +1,1 @@
+<%= render 'did_you_mean' %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,6 +55,7 @@ FIELDS:
   :TITLE_EN: 'dc_title_en_s'
   :TITLE_FR: 'dc_title_fr_s'
   :SOURCE: 'dc_source_sm'
+  :SOURCE_ICON: 'frdr_origin_icon'
   :DATE_PUBLISHED: 'dct_issued_s'
   :BBOXES: 'bboxes_sm'
   :LINES: 'lines_sm'


### PR DESCRIPTION
Changes the search results to have source repo, creators and issued date
as well as the title. It adds the ability to have source repo logos if
the document has one. It changes the sort options and moves the
pagination and sorting to be above just the search results. It also
increases the screen width used to 95% if it is above the largest
breakpoint for bootstrap to better use the screen real estate on larger
screens.