### PR TITLE
RDM-5676 Show local specific title if available

### DIFF
--- a/app/helpers/geodisy_helper.rb
+++ b/app/helpers/geodisy_helper.rb
@@ -1,4 +1,6 @@
 module GeodisyHelper
+  include Blacklight::UrlHelperBehavior
+
   ##
   # Selects the basemap used for map displays
   # @return [String]
@@ -81,6 +83,28 @@ module GeodisyHelper
     content_tag :div do
       args[:value].collect { |value| concat content_tag(:div, value) }
     end
+  end
+
+  # Try to get the correct title for the current locale, fallback to others
+  def get_locale_title(blacklight_config, document)
+    if I18n.locale == :fr then
+      # Try to use fr, then generic title, then en then id
+      fields = [:dc_title_fr_s, "dc_title_s", "dc_title_en_s", blacklight_config.document_model.unique_key]
+    else
+      # Try to use en, then generic title, then fr then id
+      fields = [:dc_title_en_s, "dc_title_s", "dc_title_fr_s", blacklight_config.document_model.unique_key]
+    end
+    f = fields.find { |field| document.key?(field) }
+    return document[f]
+  end
+
+  def get_title_url(document)
+    return url_for_document(document)
+  end
+
+  def get_title_opts(doc, counter)
+    opts = { counter: counter }
+    return document_link_params(doc, opts)
   end
 
 end

--- a/app/presenters/geodisy/show_presenter.rb
+++ b/app/presenters/geodisy/show_presenter.rb
@@ -5,19 +5,17 @@ module Geodisy
     # Shows the current locale's title, fallback to a non locale title and then the other locale
     # @return [String]
     def html_title
-      if I18n.locale == :fr then
-        # Try to use fr, then generic title, then en then id
-        fields = [:dc_title_fr_s, "dc_title_s", "dc_title_en_s", configuration.document_model.unique_key]
-      else
-        # Try to use en, then generic title, then fr then id
-        fields = [:dc_title_en_s, "dc_title_s", "dc_title_fr_s", configuration.document_model.unique_key]
-      end
-      f = fields.lazy.map { |field| field_config(field) }.detect { |field_config| field_presenter(field_config).any? }
+      f = get_locale_title()
       field_value(f)
     end
 
     # Shows the current locale's title, fallback to a non locale title and then the other locale
     def heading
+      f = get_locale_title()
+      field_value(f, except_operations: [Blacklight::Rendering::HelperMethod])
+   end
+
+    def get_locale_title
       if I18n.locale == :fr then
         # Try to use fr, then generic title, then en then id
         fields = [:dc_title_fr_s, "dc_title_s", "dc_title_en_s", configuration.document_model.unique_key]
@@ -26,8 +24,8 @@ module Geodisy
         fields = [:dc_title_en_s, "dc_title_s", "dc_title_fr_s", configuration.document_model.unique_key]
       end
       f = fields.lazy.map { |field| field_config(field) }.detect { |field_config| field_presenter(field_config).any? }
-      field_value(f, except_operations: [Blacklight::Rendering::HelperMethod])
-   end
+      return f
+    end
 
 
   end

--- a/app/views/catalog/_index_split_default.html.erb
+++ b/app/views/catalog/_index_split_default.html.erb
@@ -8,7 +8,8 @@
   <span class="col-10 col-md-9 col-xl-10">
     <div class="index_title col">
       <span class="title-wrapper">
-        <%= link_to_document document, title: document[blacklight_config.index.title_field] %>
+        <% counter = document_counter_with_offset(document_counter) %>
+        <%= link_to get_locale_title(blacklight_config, document), get_title_url(document), get_title_opts(document, counter) %>
       </span>
       <span class='status-icons'>
         <%= render partial: 'header_icons', locals: { document: document } %>


### PR DESCRIPTION
Show English title in en locale, French title in fr locale. Fall back to
regular title if neither of the en or fr titles are available.

I've added a ticket in the backlog for generating these French and English metadata in:
https://computecanada.atlassian.net/browse/RDM-5819